### PR TITLE
Fix bug in get_spec_slices when producing spectra gif on Windows

### DIFF
--- a/spectra/__init__.py
+++ b/spectra/__init__.py
@@ -396,17 +396,19 @@ class Event:
         # then makes plots for all spectra using a common y-range
         # then makes an animated gif out of all spectra plots
 
+        foldername = f'output_spectra{os.sep}'
+        start_time = spec_start.strftime('%Y-%m-%d_%H-%M-%S')
+        duration_min = (duration.total_seconds()/60)
+        base_filename = f'{foldername}spectrum_slices_start_{start_time}_step_{duration_min}min_{self.spacecraft.upper()}_{self.instrument.upper()}_{self.viewing}_{self.species}_'
+        print(base_filename)
+
         num_steps = int((spec_end-spec_start) / duration)
         for i in np.arange(0, num_steps, 1):
             t1 = spec_start + i * duration
             t2 = spec_start + (i+1) * duration
             self.get_spec(t1, t2, spec_type='integral', subtract_background=subtract_background,
                           background_start=background_start, background_end=background_end)
-
-            foldername = f'output_spectra{os.sep}'
-            start_time = str(spec_start).replace(" ", "_")
-            duration_min = (duration.total_seconds()/60)
-            filename = f'{foldername}spectrum_slices_start_{start_time}_step_{duration_min}min_{self.spacecraft.upper()}_{self.instrument.upper()}_{self.viewing}_{self.species}_{i}'
+            filename = f'{base_filename}{i}'
 
             # self.E_unc = self.DE/2.
             # self.I_unc = self.final_unc
@@ -415,8 +417,6 @@ class Event:
             self.spec_df.to_csv(filename+'.csv', index=False)
 
         # make  plots for each spec slice using common y-range:
-        base_filename = filename = f'{foldername}spectrum_slices_start_{start_time}_step_{duration_min}min_{self.spacecraft.upper()}_{self.instrument.upper()}_{self.viewing}_{self.species}_'
-        print(base_filename)
         self.plot_spec_slices(base_filename, spec_start, duration)
 
         self.make_spec_gif(base_filename)


### PR DESCRIPTION
This pull request fixes a bug in `get_spec_slices` when producing spectra gif on Windows. The previous file name contained `:`, which would crash when run on Windows.

**Filename and path handling improvements:**

* Moved the construction of `foldername`, `start_time`, `duration_min`, and `base_filename` to the start of the method, so these values are computed once and reused throughout the function instead of being recomputed inside the loop.
* Updated the file naming inside the loop to use the precomputed `base_filename`, ensuring consistent naming for all spectrum slice outputs.
* Removed redundant filename and print statements after the loop, relying on the centralized `base_filename` for subsequent plotting and GIF generation.<!-- These comments are hidden when you submit the pull request, so you do not need to remove them! -->

<!-- When you add changed ipynb files to the pull request, their metadata will be automatically checked. This will almost always trigger an error by pre-commit.ci. Don't worry! This can be fixed automatically.

When you are done with the pull request and are ready to submit it, answer here with a comment containing only "pre-commit.ci autofix" (without quotation marks). This will trigger a pre-commit process that cleans the ipynb metadata and push the changes to the pull request. This means that you should afterwards pull the changes to your local copy!  -->
