### PR TITLE
Add experimental Wind/3DP flux thresholds to multi-sc tool

### DIFF
--- a/multi_sc_plots/__init__.py
+++ b/multi_sc_plots/__init__.py
@@ -183,6 +183,9 @@ class Event:
         self.psp_epilo_channel_e = 'F'
         self.psp_epilo_channel_p = 'P'  # 'P' or 'T'
 
+        self.wind_flux_thres_e = None  # 1e3/1e6  # None
+        self.wind_flux_thres_p = None  # 1e3/1e6  # None
+
     def instrument_selection(self):
         e_checkboxes = dict(zip(self.e_instruments, [w.Checkbox(value=True, description=option[:-1], indent=False) for option in self.e_instruments]))
         p_checkboxes = dict(zip(self.p_instruments, [w.Checkbox(value=True, description=option[:-1], indent=False) for option in self.p_instruments]))
@@ -236,21 +239,31 @@ class Event:
             if type(self.viewing[key]) is str and self.viewing[key].lower() in ['antisun', 'anti-sun']:
                 self.viewing[key] = 'asun'
 
-        wind_3dp_threshold = None  # 1e3/1e6  # None
         psp_epilo_threshold_e = None  # 1e2  # None
         psp_epilo_threshold_p = None  # 1e2  # None
 
         self.psp_3600 = False  # don't change this!
 
+        # Check if thresholds for Wind/3DP data were manually set with values in the class
+        # thresholds need to be divided by 1e6 since the plotting is also doing this conversion to plot in MeV instead of eV
+        if self.wind_flux_thres_e is not None:
+            print(f"Loading Wind/3DP e data with threshold = {self.wind_flux_thres_e}!")
+            self.wind_flux_thres_e = self.wind_flux_thres_e / 1e6
+        if self.wind_flux_thres_p is not None:
+            print(f"Loading Wind/3DP p data with threshold = {self.wind_flux_thres_p}!")
+            self.wind_flux_thres_p = self.wind_flux_thres_p / 1e6
+
+
+
         ##################################################################
 
         if 'WIND/3DP e' in self.instruments:
             # # print('loading wind/3dp e omni')
-            self.wind3dp_e_df_org, self.wind3dp_e_meta = wind3dp_load(dataset="WI_SFSP_3DP", startdate=self.startdate, enddate=self.enddate, resample=None, multi_index=False, path=wind_path, threshold=wind_3dp_threshold)
+            self.wind3dp_e_df_org, self.wind3dp_e_meta = wind3dp_load(dataset="WI_SFSP_3DP", startdate=self.startdate, enddate=self.enddate, resample=None, multi_index=False, path=wind_path, threshold=self.wind_flux_thres_e)
 
         if 'WIND/3DP p' in self.instruments:
             # print('loading wind/3dp p omni')
-            self.wind3dp_p_df_org, self.wind3dp_p_meta = wind3dp_load(dataset="WI_SOSP_3DP", startdate=self.startdate, enddate=self.enddate, resample=None, multi_index=False, path=wind_path)
+            self.wind3dp_p_df_org, self.wind3dp_p_meta = wind3dp_load(dataset="WI_SOSP_3DP", startdate=self.startdate, enddate=self.enddate, resample=None, multi_index=False, path=wind_path, threshold=self.wind_flux_thres_p)
 
         if 'STEREO-A/HET e' in self.instruments or 'STEREO-A/HET p' in self.instruments:
             # print('loading stereo/het')


### PR DESCRIPTION
This pull request introduces configurable flux threshold parameters for Wind/3DP electron and proton data in the `multi_sc_plots` package. These thresholds can now be set as class attributes, allowing users to control data filtering before loading. The changes ensure that if thresholds are provided, they are converted to the correct units before being used in data loading functions.

**Configurable Wind/3DP flux thresholds:**

* Added `wind_flux_thres_e` and `wind_flux_thres_p` attributes to the class initializer in `__init__.py`, allowing users to set custom thresholds for Wind/3DP electron and proton data.
* Updated the `load_data` method to check if these thresholds are set, convert them from eV to MeV (by dividing by 1e6), and pass them to the `wind3dp_load` function for data filtering.… improved data loading

## This is an experimental feature! Use with caution!

**How to use**

Before executing `E.load_data(startdate, enddate, instruments, data_path=data_path)` in the Notebook, the thresholds need to be defined in Flux units per MeV with:
```
E.wind_flux_thres_e = 1000
E.wind_flux_thres_p = 0.2
```
Of course the numbers need to be adjusted for each use case. When running `E.load_data()` afterwards, it will print out these used thresholds. All intensities above these thresholds will be removed.

To revert back to the default settings after defining some thresholds, run:
```
E.wind_flux_thres_e = None
E.wind_flux_thres_p = None
```
or restart the Notebook.

<!-- These comments are hidden when you submit the pull request, so you do not need to remove them! -->

<!-- When you add changed ipynb files to the pull request, their metadata will be automatically checked. This will almost always trigger an error by pre-commit.ci. Don't worry! This can be fixed automatically.

When you are done with the pull request and are ready to submit it, answer here with a comment containing only "pre-commit.ci autofix" (without quotation marks). This will trigger a pre-commit process that cleans the ipynb metadata and push the changes to the pull request. This means that you should afterwards pull the changes to your local copy!  -->
