### PR TITLE
Remove wrongly introduce code snippet

### DIFF
--- a/fit_spectra/run_spectra_fit.py
+++ b/fit_spectra/run_spectra_fit.py
@@ -94,16 +94,9 @@ def run_the_fit(path, data, save, use_filename_as_title = False, channels_to_exc
     x_err = None
     y_err = None
 
-    if 'E_err' in data:
-        x_err = data['E_err']
-        if x_err.isnull().all():
-            x_err = None
-    if 'I_err' in data:
-        y_err = data['I_err'] 
-
     if 'E_err' in dataframe_to_fit:
         x_err = dataframe_to_fit['E_err']
-        #checking if uncertainties for energy and intensity are NaNs
+        # checking if uncertainties for energy and intensity are NaNs
         if x_err.isnull().all():
             x_err = None
     


### PR DESCRIPTION
This pull request makes a small update to the error handling logic updated in #119 in the `run_the_fit` function in `fit_spectra/run_spectra_fit.py`. It removes a code block that was wrongly introduced and that set `x_err` and `y_err` from the `data` dictionary. It shouldn't have had any effect because the variables were directly afterwards replaced with the correct ones.

<!-- These comments are hidden when you submit the pull request, so you do not need to remove them! -->

<!-- When you add changed ipynb files to the pull request, their metadata will be automatically checked. This will almost always trigger an error by pre-commit.ci. Don't worry! This can be fixed automatically.

When you are done with the pull request and are ready to submit it, answer here with a comment containing only "pre-commit.ci autofix" (without quotation marks). This will trigger a pre-commit process that cleans the ipynb metadata and push the changes to the pull request. This means that you should afterwards pull the changes to your local copy!  -->
