### PR TITLE
Enhance both onset notebooks with data level selection in widgets

### DIFF
--- a/SEP_PyOnset.ipynb
+++ b/SEP_PyOnset.ipynb
@@ -2,10 +2,17 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "0",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[91mWARNING: \u001b[0mBreaking changes in SEPpy v0.4.0: The metadata for SOHO/EPHIN, SOHO/ERNE, STEREO/SEPT, and Wind/3DP have changed! See https://github.com/serpentine-h2020/SEPpy/releases/tag/v0.4.0 for details. (You can ignore this if you do not invoke SEPpy manually.)\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -39,24 +46,26 @@
     "\n",
     "> Viewing: sun\n",
     "\n",
-    "> Species: ions"
+    "> Species: ions\n",
+    "\n",
+    "> Data level: L2"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "2",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d7bc4ce08c6f4fbea7f40de8a4cad100",
+       "model_id": "3ed325931d5649bda484a82a515e0e9d",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Dropdown(description='Spacecraft:', options=('PSP', 'SOHO', 'Solar Orbiter', 'STEREO-A', 'STEREO-B', 'Wind'), …"
+       "Dropdown(description='Spacecraft:', index=3, options=('BepiColombo', 'PSP', 'SOHO', 'Solar Orbiter', 'STEREO-A…"
       ]
      },
      "metadata": {},
@@ -65,12 +74,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3f8d93ed3d7440d3bc54f5a7c5e4fabc",
+       "model_id": "b9929dfb2a3e48e3a6e54132e8bb7192",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Dropdown(description='Sensor:', options=('isois-epihi', 'isois-epilo'), value='isois-epihi')"
+       "Dropdown(description='Sensor:', options=('EPT', 'HET', 'STEP'), value='EPT')"
       ]
      },
      "metadata": {},
@@ -79,12 +88,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a542825e2c694f85b803a434a078e21b",
+       "model_id": "04c38b56aeeb429cad377e059fa0ce5e",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Dropdown(description='Viewing:', options=('A', 'B'), value='A')"
+       "Dropdown(description='Viewing:', options=('sun', 'asun', 'north', 'south'), value='sun')"
       ]
      },
      "metadata": {},
@@ -93,12 +102,26 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0634086fae0440a5a8bf49f69f5d9d47",
+       "model_id": "7b14a78f5de34e9f9cdca5159b6a6dc9",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Dropdown(description='Species:', options=('protons', 'electrons'), value='protons')"
+       "Dropdown(description='Species:', options=('ions', 'electrons'), value='ions')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4d67116575e44229954b97b23d9cb346",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Dropdown(description='Data level:', options=('L2',), value='L2')"
       ]
      },
      "metadata": {},
@@ -121,7 +144,8 @@
     "w.spacecraft_drop.value = \"Solar Orbiter\"\n",
     "w.sensor_drop.value = \"EPT\"\n",
     "w.view_drop.value = \"sun\"\n",
-    "w.species_drop.value = \"ions\""
+    "w.species_drop.value = \"ions\"\n",
+    "w.level_drop.value = \"L2\""
    ]
   },
   {
@@ -1887,9 +1911,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "SEP Tools",
+   "display_name": "sep_tools",
    "language": "python",
-   "name": "sep_tools"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1900,7 +1924,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,

--- a/SEP_PyOnset.ipynb
+++ b/SEP_PyOnset.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "0",
    "metadata": {},
    "outputs": [
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "2",
    "metadata": {},
    "outputs": [
@@ -1911,9 +1911,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "sep_tools",
+   "display_name": "SEP Tools",
    "language": "python",
-   "name": "python3"
+   "name": "sep_tools"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1924,8 +1924,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.4"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/SEP_Regression-Onset.ipynb
+++ b/SEP_Regression-Onset.ipynb
@@ -173,8 +173,8 @@
     "end_date = dt.datetime(2022, 1, 21)\n",
     "\n",
     "if select_data._seppy_selected(select_data.data_file):\n",
-    "    import seppy.tools.widgets as w\n",
-    "    display(w.spacecraft_drop, w.sensor_drop, w.view_drop, w.species_drop)"
+    "    import seppy.tools.widgets_onset as w\n",
+    "    display(w.spacecraft_drop, w.sensor_drop, w.view_drop, w.species_drop, w.level_drop)"
    ]
   },
   {
@@ -200,7 +200,7 @@
     "    data_path = jupyterhub_data_path(data_path)\n",
     "    # Initializes the SEPpy Event object\n",
     "    seppy_data = Event(spacecraft=w.spacecraft_drop.value, sensor=w.sensor_drop.value, species=w.species_drop.value,\n",
-    "                         start_date=start_date, end_date=end_date, data_level=\"l2\",\n",
+    "                         start_date=start_date, end_date=end_date, data_level=w.level_drop.value,\n",
     "                         data_path=data_path, viewing=w.view_drop.value)\n",
     "\n",
     "    # Exports the SEPpy data and metadata to pandas dataframes and a dictionary\n",


### PR DESCRIPTION
This pull request updates both onset notebooks to add support for selecting the data level (`L2`) via the dropdown widget and ensures that the selected data level is passed to the underlying SEPpy event loader. 

Key changes:

**Widget and UI enhancements:**

* Added a new `Data level` dropdown (`w.level_drop`) to both `SEP_PyOnset.ipynb` and `SEP_Regression-Onset.ipynb`, allowing users to select the data level (currently mostly `L2` is fixed). This dropdown is now included in the displayed widgets and its value is used when loading SEPpy data.

* Updated the widget import from `seppy.tools.widgets` to `seppy.tools.widgets_onset` in `SEP_Regression-Onset.ipynb` to match the new widget structure.

**Notebook output:**

* Adjusted widget output cells to reflect the addition of the new dropdown and updated the displayed dropdowns for spacecraft, sensor, viewing, and species.
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them! -->

<!-- When you add changed ipynb files to the pull request, their metadata will be automatically checked. This will almost always trigger an error by pre-commit.ci. Don't worry! This can be fixed automatically.

When you are done with the pull request and are ready to submit it, answer here with a comment containing only "pre-commit.ci autofix" (without quotation marks). This will trigger a pre-commit process that cleans the ipynb metadata and push the changes to the pull request. This means that you should afterwards pull the changes to your local copy!  -->
