### PR TITLE
Fix division by zero in PAD-and-Anisotropy Tool since lmfit 1.3.4

### DIFF
--- a/anisotropy/anisotropy_functions_updated.py
+++ b/anisotropy/anisotropy_functions_updated.py
@@ -205,7 +205,20 @@ def anisotropy_legendre_fit(y,x,y_err = None):
         res = model.fit(y, params, x=x,weights=weights)
         results.append(res)
         bics.append(res.bic)
-        anis.append(res.params["b"].value/res.params["a"].value)
+        #
+        # The following caused a division by zero crash since lmfit 1.3.4
+        # because it internaly started using floats instead of np.floats (which
+        # allowed division by zero to return inf instead of crashing). Fixed by
+        # setting anisotropy to NaN when a=0.0 (mind that before it technically
+        # ended up as np.inf).
+        # anis.append(res.params["b"].value/res.params["a"].value)  # old code
+        a_val = res.params["a"].value
+        b_val = res.params["b"].value
+        if a_val == 0.0:
+            anis.append(np.nan)
+        else:
+            anis.append(b_val / a_val)
+        #
         degree += 1
     idx = np.nanargmin(bics)
     return results[idx], anis[idx]


### PR DESCRIPTION
This pull request addresses a division by zero issue in the `anisotropy_legendre_fit` function in `anisotropy/anisotropy_functions_updated.py` that caused crashing since [lmfit 1.3.4](https://github.com/lmfit/lmfit-py/releases/tag/1.3.4). With that version, lmfit internally started using floats instead of np.floats, which allowed division by zero to return inf instead of crashing. The change ensures that if the parameter `a` is zero, the anisotropy value is set to `np.nan` instead of causing a crash or returning infinity.

Bug fix for division by zero:

* Updated the calculation of anisotropy to set the value to `np.nan` when parameter `a` is zero, preventing a crash due to division by zero in recent versions of `lmfit`.
<!-- These comments are hidden when you submit the pull request, so you do not need to remove them! -->

<!-- When you add changed ipynb files to the pull request, their metadata will be automatically checked. This will almost always trigger an error by pre-commit.ci. Don't worry! This can be fixed automatically.

When you are done with the pull request and are ready to submit it, answer here with a comment containing only "pre-commit.ci autofix" (without quotation marks). This will trigger a pre-commit process that cleans the ipynb metadata and push the changes to the pull request. This means that you should afterwards pull the changes to your local copy!  -->
