### PR TITLE
Spatial-Distribution: Errorbars/regions added to figs; coord swap bool stored to file; data desc added to notebook; odrpack incorporated

### DIFF
--- a/SEP_Spatial-Distribution.ipynb
+++ b/SEP_Spatial-Distribution.ipynb
@@ -353,9 +353,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "21",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Set to False to skip this process \n",
@@ -421,9 +419,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "25",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "solar_event.calc_Gaussian_fit()"
@@ -504,9 +500,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "31",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Plot just the curve for a given timestep\n",
@@ -618,7 +612,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "77562662-83a5-490b-8f94-07a208693456",
+   "id": "38",
    "metadata": {},
    "source": [
     "## Glossary\n",
@@ -662,7 +656,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69a5a6ac-d3ee-4a1a-8209-985d22587d4f",
+   "id": "39",
    "metadata": {},
    "source": [
     "## Data details\n",
@@ -682,7 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7d9b042-2b6b-41be-873b-8e7ccfb576d4",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -690,9 +684,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "SEP Tools",
    "language": "python",
-   "name": "python3"
+   "name": "sep_tools"
   },
   "language_info": {
    "codemirror_mode": {
@@ -703,8 +697,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/spatial_analysis/__init__.py
+++ b/spatial_analysis/__init__.py
@@ -5,7 +5,8 @@ import pandas as pd
 from copy import deepcopy
 
 from scipy.optimize import curve_fit, OptimizeWarning
-from scipy import odr
+from scipy import odr # Depreciated
+from odrpack import odr_fit
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -475,7 +476,13 @@ def horizons_speasy_location_loader(observers, dates, data_path, resampling, sou
             sm_loop = pd.read_csv(data_path+filename, 
                                   index_col=0, header=[0,1],
                                   parse_dates=True, na_values='nan')
-            return sm_loop
+
+            beyond_limits = False
+            for sc, col in sm_loop.columns:
+                if col == 'plot_separation_long':
+                    if 'yes' in sm_loop[(sc,col)]:
+                        beyond_limits = True
+            return sm_loop, beyond_limits
 
     # Set up the start and end times
     ## Use 2 hours before given flare start time for background if needed
@@ -586,7 +593,7 @@ def horizons_speasy_location_loader(observers, dates, data_path, resampling, sou
         
         hdf1 = hc_dict[obs]
 
-        ftlng_arr, fl_err_arr, sep_arr = ([] for i in range(3))
+        ftlng_arr, fl_err_arr, sep_arr, swapd_coord_sides = ([] for i in range(4))
         for tt in hdf1.index:
             footlng = move_along_parker_spiral(hdf1.loc[tt,'r_dist'],
                                                [hdf1.loc[tt,'long'], hdf1.loc[tt,'lat']],
@@ -600,11 +607,15 @@ def horizons_speasy_location_loader(observers, dates, data_path, resampling, sou
             #sep_arr.append(footlng[0]-source_loc) # footpoint distance to flare
             if excd_limits:
                 beyond_limits = True
+                swapd_coord_sides.append('yes')
+            else:
+                swapd_coord_sides.append('no')
             
 
         hdf1['foot_long'] = ftlng_arr
         hdf1['foot_long_error'] = fl_err_arr
         hdf1['long_sep'] = sep_arr
+        hdf1['plot_separation_long'] = swapd_coord_sides
 
         hc_dict[obs] = hdf1
 
@@ -1248,7 +1259,7 @@ def log_gauss_function(x, logA, x0, sigma):
     return logA - ( (x - x0)**2 ) / ( 2 * np.log(10) * sigma**2 )
 
 
-def log_gauss_function_beta(beta_params, x):
+def log_gauss_function_beta(x, beta_params):
     """The same as log_gauss_function but 'curve_fit' and 'odr' require a different
     ordering of the parameters."""
     a, x0, sigma = beta_params
@@ -1261,10 +1272,11 @@ def odr_gauss_fit(dict_1timestep, prev_results={'A': np.nan, 'X0': np.nan, 'sigm
     Input: one timesteps worth of values, and the results of the previous timesteps fit."""
 
     df = pd.DataFrame(dict_1timestep)
+    # print(df)
 
     # Remove zero and nan values
     for i, row in df.iterrows():
-        if (row['y'] == 0.0) or (np.isnan(row['y'])):
+        if (row['y'] == 0.0) or (np.isnan(row['y'])) or (row['x'] == 0.0) or (np.isnan(row['x'])):
             df.drop([i], inplace=True) # Drops the whole row
 
     # Must have at least 3 data points to calculate
@@ -1279,39 +1291,74 @@ def odr_gauss_fit(dict_1timestep, prev_results={'A': np.nan, 'X0': np.nan, 'sigm
         try:
             popt, pcov = curve_fit(log_gauss_function, df['x'], df['y'],
                                   p0=[max(df['y']), df['x'][ df['y'].idxmax() ], 20]) # max amplitude, position of the max amplitude, width
+            # print('the scipy results are: ')
+            # print(popt)
             prev_results = {'A': float(popt[0]), 'X0': float(popt[1]), 'sigma': float(popt[2])}
         except:
-            print("No updated Gaussian parameters were found")
-            prev_results = {'A': np.nan, 'X0': np.nan, 'sigma': np.nan}
+            # print("No updated Gaussian parameters were found")
+            prev_results = {'A': max(df['y']), 'X0': df['x'][ df['y'].idxmax() ], 'sigma': 20}
 
-    # Set up the ODR functions
-    odr_model = odr.Model(log_gauss_function_beta)
-    if np.isnan(df['yerr']).any(): # If there are any nan's then it won't calculate properly
-        odr_data = odr.RealData(x=df['x'], y=df['y'], sx=df['xerr'])
+    # Run the ODR functions
+    # print("The prev results are: ")
+    # print(prev_results)
+    # jax=input('yah')
+    if np.isnan(df['yerr']).any(): # If there are any nans then it might break
+        out = odr_fit(log_gauss_function_beta, # function
+                      df['x'], df['y'], # x and y arrays
+                      prev_results, # estimated parameters
+                      weight_x=((df['xerr'])**(-2) ) ) # uncertainty values
     else:
-        odr_data = odr.RealData(x=df['x'], y=df['y'], sx=df['xerr'], sy=df['yerr'])
-
-    odr_setup = odr.ODR(odr_data, odr_model, beta0=[prev_results['A'], prev_results['X0'], prev_results['sigma']])
-    out = odr_setup.run()
+        out = odr_fit(log_gauss_function_beta, # function
+                      df['x'], df['y'], # x and y arrays
+                      [prev_results['A'], prev_results['X0'], prev_results['sigma']], # estimated parameters
+                      weight_x=( (df['xerr'])**(-2) ), # uncertainty values
+                      weight_y=( (df['yerr'])**(-2) ) )
+    # print(out)
+    # print(out.beta[0])
+    ########################################
+    ## DEPRECIATED CODE. Kept for historical purposes.
+    # odr_model = odr.Model(log_gauss_function_beta)
+    # if np.isnan(df['yerr']).any(): # If there are any nan's then it won't calculate properly
+    #     odr_data = odr.RealData(x=df['x'], y=df['y'], sx=df['xerr'])
+    # else:
+    #     odr_data = odr.RealData(x=df['x'], y=df['y'], sx=df['xerr'], sy=df['yerr'])
+    #
+    # odr_setup = odr.ODR(odr_data, odr_model, beta0=[prev_results['A'], prev_results['X0'], prev_results['sigma']])
+    # out = odr_setup.run()
 
     # Confirm that ODR found a fitted curve
-    stopreason = []
-    for reasons in out.stopreason:
-        if 'convergence' in reasons:
-            if (abs(out.beta[1]) > 270) or (abs(out.beta[2]) > 180): # X0 > 360 or sigma >180
-                stopreason.append('fail')
-            else:
-                stopreason.append('pass')
+    # stopreason = []
+    # for reasons in out.stopreason:
+    #     if 'convergence' in reasons:
+    #         if (abs(out.beta[1]) > 270) or (abs(out.beta[2]) > 180): # X0 > 360 or sigma >180
+    #             stopreason.append('fail')
+    #         else:
+    #             stopreason.append('pass')
+    #     else:
+    #         stopreason.append('fail')
+    #
+    # if 'pass' not in stopreason:
+    #     return {'A': np.nan, 'X0': np.nan, 'sigma': np.nan,
+    #             'A err': np.nan, 'X0 err': np.nan, 'sigma err': np.nan, 'res':np.nan}
+    ########################################
+    if 'convergence' in out.stopreason:
+        if (abs(out.beta[1]) > 270) or (abs(out.beta[2]) > 180): #center is out of bounds; width is too large
+            out_dict = {'A': np.nan, 'X0': np.nan, 'sigma': np.nan,
+                        'A err': np.nan, 'X0 err': np.nan, 'sigma err': np.nan,
+                        'res':np.nan}
         else:
-            stopreason.append('fail')
+            out_dict = {'A': float(out.beta[0]), 'X0': float(out.beta[1]),
+                        'sigma': float(out.beta[2]), 'A err': float(out.sd_beta[0]),
+                        'X0 err': float(out.sd_beta[1]), 'sigma err': float(out.sd_beta[2]),
+                        'res': float(out.res_var)}
+    else:
+        out_dict = {'A': np.nan, 'X0': np.nan, 'sigma': np.nan,
+                    'A err': np.nan, 'X0 err': np.nan, 'sigma err': np.nan,
+                    'res':np.nan}
 
-    if 'pass' not in stopreason:
-        return {'A': np.nan, 'X0': np.nan, 'sigma': np.nan,
-                'A err': np.nan, 'X0 err': np.nan, 'sigma err': np.nan, 'res':np.nan}
+    return out_dict
 
-    return {'A': float(out.beta[0]), 'X0': float(out.beta[1]), 'sigma': float(out.beta[2]),
-            'A err': float(out.sd_beta[0]), 'X0 err': float(out.sd_beta[1]), 'sigma err': float(out.sd_beta[2]),
-            'res': float(out.res_var)}
+
 
 def fit_gauss_curves_to_data(sc_dict, data_path, reference, flare_loc, peak_data, energy_range_label, plot_foot_sep_limits):
     """Read in the full df, calculate the curve at each timestep, save the results to new columns."""
@@ -1499,6 +1546,7 @@ def find_peak_intensity(sc_dict, data_path, date, window_length=10):
                       'xreal': peak_xreal}
     peak_fit_results = odr_gauss_fit(peak_data_dict)
     # The function finds an initial estimate for the parameters so we don't need to pass one
+    # print(peak_fit_results)
 
     peak_data_results = peak_data_dict | peak_fit_results #combine the results to the given values.
 
@@ -1559,6 +1607,10 @@ def plot_peak_intensity(sc_dict, data_path, date, peak_data_results, energy_rang
 
         # Plot the full time series
         tseries_ax.semilogy(sc_dict[sc]['Flux'], color=mrkr['color'])
+        tseries_ax.fill_between(x=sc_dict[sc].index,
+                                y1=sc_dict[sc]['Flux'] - sc_dict[sc]['Uncertainty'],
+                                y2=sc_dict[sc]['Flux'] + sc_dict[sc]['Uncertainty'],
+                                alpha=0.3, color=mrkr['color'])
 
     tseries_ax.legend(loc='upper center', bbox_to_anchor=(0.5,1.2), ncols=2, fontsize=8)
 
@@ -1584,7 +1636,7 @@ def plot_peak_intensity(sc_dict, data_path, date, peak_data_results, energy_rang
                          label=f"Reference at {flare_loc[0]}{DEGREE_TEXT}")
 
     # Add the text
-    gauss_text = f"Center = {peak_data_results['X0']:.1f}{DEGREE_TEXT}\n"
+    gauss_text = f"Center = {peak_data_results['X0']+flarelong:.1f}{DEGREE_TEXT}\n"
     gauss_text = f"{gauss_text}Width = {peak_data_results['sigma']:.1f}{DEGREE_TEXT}"
     box_obj = AnchoredText(gauss_text, frameon=True, loc='upper left', pad=0.5, prop={'size':8})
     plt.setp(box_obj.patch, facecolor='aliceblue', alpha=0.8)
@@ -1707,12 +1759,22 @@ def plot_curve_and_timeseries(gauss_values, sc_df, full_df, data_path, timestep,
 
     for n in range(len(sc_df['sc'])):
         markers = marker_settings[sc_df['sc'][n]]
-        gauss_ax.semilogy(sc_df[gauss_xlabel][n], 10**(sc_df['y'][n]), label=sc_df['sc'][n],
-                          marker=markers['marker'], color=markers['color'])
+        # gauss_ax.semilogy(sc_df[gauss_xlabel][n], 10**(sc_df['y'][n]), label=sc_df['sc'][n],
+        #                   marker=markers['marker'], color=markers['color'])
+        gauss_ax.errorbar(sc_df[gauss_xlabel][n],
+                          10**(sc_df['y'][n]),
+                          xerr=sc_df['xerr'][n],
+                          yerr=10**(sc_df['yerr'][n]),
+                          label=sc_df['sc'][n], marker=markers['marker'],
+                          color=markers['color'], ecolor=markers['color'])
 
         # Plot the timeseries data
         tseries_ax.semilogy(full_df[sc_df['sc'][n]]['Flux'],
                             color=markers['color'], label=sc_df['sc'][n])
+        tseries_ax.fill_between(x=full_df[sc_df['sc'][n]].index,
+                                y1=full_df[sc_df['sc'][n]]['Flux'] - full_df[sc_df['sc'][n]]['Uncertainty'],
+                                y2=full_df[sc_df['sc'][n]]['Flux'] + full_df[sc_df['sc'][n]]['Uncertainty'],
+                            color=markers['color'], alpha=0.3)
     gauss_ax.legend(bbox_to_anchor=(0.2, 1.03, 1.0, 0.1), loc='upper left', ncols=6, fontsize=6)
 
     gauss_ax.set_xlim(xlimits[0]-20, xlimits[1]+20)
@@ -1762,8 +1824,14 @@ def plot_one_timestep_curve(sc_dict, data_path, timestep, channel_labels, flare_
         # print(timestep)
         # print(x_col_label)
         # print(sdf)
-        ax.semilogy(sdf.loc[timestep, x_col_label], sdf.loc[timestep, 'Flux'],
-                    label=mrkr['label'], color=mrkr['color'], marker=mrkr['marker'])
+        # ax.semilogy(sdf.loc[timestep, x_col_label], sdf.loc[timestep, 'Flux'],
+        #             label=mrkr['label'], color=mrkr['color'], marker=mrkr['marker'])
+        ax.errorbar(sdf.loc[timestep, x_col_label],
+                    sdf.loc[timestep, 'Flux'],
+                    xerr=sdf.loc[timestep, 'foot_long_error'],
+                    yerr=sdf.loc[timestep, 'Uncertainty'],
+                    label=mrkr['label'], marker=mrkr['marker'],
+                    color=mrkr['color'], ecolor=mrkr['color'])
 
         ylimits[0] = np.nanmin([ylimits[0], np.nanmin(sdf.loc[timestep,'Flux'])])
         ylimits[1] = np.nanmax([ylimits[1], np.nanmax(sdf.loc[timestep,'Flux'])])

--- a/spatial_analysis/__init__.py
+++ b/spatial_analysis/__init__.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 from scipy.optimize import curve_fit, OptimizeWarning
 from scipy import odr # Depreciated
-from odrpack import odr_fit
+#from odrpack import odr_fit
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -68,6 +68,12 @@ SIGMA_TEXT = r'$\sigma$'
 PM_SYMB = r"$\pm$"
 SQUARED_TEXT = r"$^{2}$"
 NEGPOWER_TEXT = r"$^{-1}$"
+
+####### ODRPACK NOT AVAILABLE IN HUB YET
+use_old_odr_method = True
+if not use_old_odr_method:
+    from odrpack import odr_fit
+
 
 
 ################################################
@@ -1259,7 +1265,14 @@ def log_gauss_function(x, logA, x0, sigma):
     return logA - ( (x - x0)**2 ) / ( 2 * np.log(10) * sigma**2 )
 
 
-def log_gauss_function_beta(x, beta_params):
+def log_gauss_function_beta_odrpack(x, beta_params):
+    """The same as log_gauss_function but 'curve_fit' and 'odr' require a different
+    ordering of the parameters."""
+    a, x0, sigma = beta_params
+    result = log_gauss_function(x, a, x0, sigma)
+    return result
+
+def log_gauss_function_beta(beta_params, x):
     """The same as log_gauss_function but 'curve_fit' and 'odr' require a different
     ordering of the parameters."""
     a, x0, sigma = beta_params
@@ -1302,59 +1315,69 @@ def odr_gauss_fit(dict_1timestep, prev_results={'A': np.nan, 'X0': np.nan, 'sigm
     # print("The prev results are: ")
     # print(prev_results)
     # jax=input('yah')
-    if np.isnan(df['yerr']).any(): # If there are any nans then it might break
-        out = odr_fit(log_gauss_function_beta, # function
-                      df['x'], df['y'], # x and y arrays
-                      prev_results, # estimated parameters
-                      weight_x=((df['xerr'])**(-2) ) ) # uncertainty values
-    else:
-        out = odr_fit(log_gauss_function_beta, # function
-                      df['x'], df['y'], # x and y arrays
-                      [prev_results['A'], prev_results['X0'], prev_results['sigma']], # estimated parameters
-                      weight_x=( (df['xerr'])**(-2) ), # uncertainty values
-                      weight_y=( (df['yerr'])**(-2) ) )
-    # print(out)
-    # print(out.beta[0])
-    ########################################
-    ## DEPRECIATED CODE. Kept for historical purposes.
-    # odr_model = odr.Model(log_gauss_function_beta)
-    # if np.isnan(df['yerr']).any(): # If there are any nan's then it won't calculate properly
-    #     odr_data = odr.RealData(x=df['x'], y=df['y'], sx=df['xerr'])
-    # else:
-    #     odr_data = odr.RealData(x=df['x'], y=df['y'], sx=df['xerr'], sy=df['yerr'])
-    #
-    # odr_setup = odr.ODR(odr_data, odr_model, beta0=[prev_results['A'], prev_results['X0'], prev_results['sigma']])
-    # out = odr_setup.run()
-
-    # Confirm that ODR found a fitted curve
-    # stopreason = []
-    # for reasons in out.stopreason:
-    #     if 'convergence' in reasons:
-    #         if (abs(out.beta[1]) > 270) or (abs(out.beta[2]) > 180): # X0 > 360 or sigma >180
-    #             stopreason.append('fail')
-    #         else:
-    #             stopreason.append('pass')
-    #     else:
-    #         stopreason.append('fail')
-    #
-    # if 'pass' not in stopreason:
-    #     return {'A': np.nan, 'X0': np.nan, 'sigma': np.nan,
-    #             'A err': np.nan, 'X0 err': np.nan, 'sigma err': np.nan, 'res':np.nan}
-    ########################################
-    if 'convergence' in out.stopreason:
-        if (abs(out.beta[1]) > 270) or (abs(out.beta[2]) > 180): #center is out of bounds; width is too large
+    if not use_old_odr_method: # Using new odrpack function
+        print('Using odrpack, good?')
+        if np.isnan(df['yerr']).any(): # If there are any nans then it might break
+            out = odr_fit(log_gauss_function_beta_odrpack, # function
+                        df['x'], df['y'], # x and y arrays
+                        prev_results, # estimated parameters
+                        weight_x=((df['xerr'])**(-2) ) ) # uncertainty values
+        else:
+            out = odr_fit(log_gauss_function_beta_odrpack, # function
+                        df['x'], df['y'], # x and y arrays
+                        [prev_results['A'], prev_results['X0'], prev_results['sigma']], # estimated parameters
+                        weight_x=( (df['xerr'])**(-2) ), # uncertainty values
+                        weight_y=( (df['yerr'])**(-2) ) )
+        # print(out)
+        # print(out.beta[0])
+        if 'convergence' in out.stopreason:
+            if (abs(out.beta[1]) > 270) or (abs(out.beta[2]) > 180): #center is out of bounds; width is too large
+                out_dict = {'A': np.nan, 'X0': np.nan, 'sigma': np.nan,
+                            'A err': np.nan, 'X0 err': np.nan, 'sigma err': np.nan,
+                            'res':np.nan}
+            else:
+                out_dict = {'A': float(out.beta[0]), 'X0': float(out.beta[1]),
+                            'sigma': float(out.beta[2]), 'A err': float(out.sd_beta[0]),
+                            'X0 err': float(out.sd_beta[1]), 'sigma err': float(out.sd_beta[2]),
+                            'res': float(out.res_var)}
+        else:
             out_dict = {'A': np.nan, 'X0': np.nan, 'sigma': np.nan,
                         'A err': np.nan, 'X0 err': np.nan, 'sigma err': np.nan,
                         'res':np.nan}
+    ########################################
+    ## DEPRECIATED CODE. Kept for historical purposes.
+    else:
+        #jax=input('Using scipy.odr, good?')
+        odr_model = odr.Model(log_gauss_function_beta)
+        if np.isnan(df['yerr']).any(): # If there are any nan's then it won't calculate properly
+            odr_data = odr.RealData(x=df['x'], y=df['y'], sx=df['xerr'])
+        else:
+            odr_data = odr.RealData(x=df['x'], y=df['y'], sx=df['xerr'], sy=df['yerr'])
+
+        odr_setup = odr.ODR(odr_data, odr_model, beta0=[prev_results['A'], prev_results['X0'], prev_results['sigma']])
+        out = odr_setup.run()
+
+        # Confirm that ODR found a fitted curve
+        stopreason = []
+        for reasons in out.stopreason:
+            if 'convergence' in reasons:
+                if (abs(out.beta[1]) > 270) or (abs(out.beta[2]) > 180): # X0 > 360 or sigma >180
+                    stopreason.append('fail')
+                else:
+                    stopreason.append('pass')
+            else:
+                stopreason.append('fail')
+
+        if 'pass' not in stopreason:
+            out_dict = {'A': np.nan, 'X0': np.nan, 'sigma': np.nan,
+                    'A err': np.nan, 'X0 err': np.nan, 'sigma err': np.nan, 'res':np.nan}
         else:
             out_dict = {'A': float(out.beta[0]), 'X0': float(out.beta[1]),
                         'sigma': float(out.beta[2]), 'A err': float(out.sd_beta[0]),
                         'X0 err': float(out.sd_beta[1]), 'sigma err': float(out.sd_beta[2]),
                         'res': float(out.res_var)}
-    else:
-        out_dict = {'A': np.nan, 'X0': np.nan, 'sigma': np.nan,
-                    'A err': np.nan, 'X0 err': np.nan, 'sigma err': np.nan,
-                    'res':np.nan}
+    ########################################
+
 
     return out_dict
 


### PR DESCRIPTION
- Figures now consistently plot with errors and uncertainties included.
- When wrapping the coordinates around the 180-degree 'max' (using Stonyhurst), a bool was stored to instruct the plotters to show separation longitude in the x-axis instead of footpoint longitude. This bool was not stored in the CSV file and thus would break when retrieving already downloaded data.
- Description of datasets used in the tool is added to the bottom of the notebook to comply with [Issue#59](https://github.com/soler-he/sep_tools/issues/59).
- Swapped using scipy.odr to odrpack, to comply with [Issue#105](https://github.com/soler-he/sep_tools/issues/105). Functions perfectly for the nominal values. Uncertainty ranges display incorrectly, but seemingly calculate correctly. This is an ongoing issue that will be fixed in the near future.

<!-- These comments are hidden when you submit the pull request, so you do not need to remove them! -->

<!-- When you add changed ipynb files to the pull request, their metadata will be automatically checked. This will almost always trigger an error by pre-commit.ci. Don't worry! This can be fixed automatically.

When you are done with the pull request and are ready to submit it, answer here with a comment containing only "pre-commit.ci autofix" (without quotation marks). This will trigger a pre-commit process that cleans the ipynb metadata and push the changes to the pull request. This means that you should afterwards pull the changes to your local copy!  -->
